### PR TITLE
queue messages into a channel that workers drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ to support in this service, as it just needs to ignore the extra headers
 not support it and this it is rejected. If your client-side code can handle it,
 uncomment the line referring to it.
 
-The service could probably be made more efficient by queuing up APNs accesses
-and not waiting for them to finish before returning from the request handler,
-but this has not been implemented at the moment.
-
 ## Configuration ##
 
 The service will read a few environment variables that let you make some adjustments.


### PR DESCRIPTION
Per discussion in [discord](https://discord.com/channels/231908446830723072/231908446830723072/1038467394236071936), refactor the notification service to queue up messages and immediately respond to incoming requests. This closely follows the structure of the [Android version](https://github.com/mastodon/webpush-fcm-relay/blob/4860a812a4fa29efa719aa12837d3824231ff8f4/webpush-fcm-relay.go).

## Considerations

- We'll now always send an HTTP 201 on notification, since we don't know yet if the push will succeed
- ❗ **I did not run/test this code** since I don't have an active Apple developer account and can't generate a certificate (that section of my UI is [blank](https://cdn.zappy.app/b7dd9017fbc967783eef81dbcfa9e34e.png)). The changes are simple enough, but please verify it still works before deploying.
- In the interest of simplicity, I didn't make the queue size and number of worker threads configurable. Happy to add flags for that (or change the defaults) if you anticipate wanting to tweak them. 