### PR TITLE
Move worker & queue configuration into CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ uncomment the line referring to it.
 
 ## Configuration ##
 
+### Runtime Flags
+
+- `-max-queue-size`: sets the size of the channel that buffers incoming notifications. Raising this value will consume more RAM (Go will pre-allocate the entire buffer to hold `N * size of message`). Defaults to `4096`.
+- `-max-workers`: sets the number of parallel goroutines that will send notifications to Apple. Raising it will drain the queue more quickly at a small cost to increased resource usage. Each goroutine uses gets approx. 2kb of memory. This can safely scale into the thousands, if needed. See [this post](https://tpaschalis.github.io/goroutines-size/) for scaling considerations. Defaults to `8`.
+
+### Environment Variables
+
 The service will read a few environment variables that let you make some adjustments.
 
 * `P12_FILENAME`: The name of the p12 file to use for the push notification certificate.

--- a/toot-relay.go
+++ b/toot-relay.go
@@ -55,7 +55,7 @@ func worker(workerId int) {
 
 		if err != nil {
 			log.Println("Push error:", err)
-			return
+			continue
 		}
 
 		if res.Sent() {


### PR DESCRIPTION
Adds configuration flags for num workers and queue size, plus some docs. 

Also, address a comment from the last pr: https://github.com/Gargron/toot-relay/pull/1#discussion_r1014758176